### PR TITLE
Hotfix: container stretch in smaller viewport

### DIFF
--- a/css/info-review-899.css
+++ b/css/info-review-899.css
@@ -49,6 +49,11 @@
 
 .info-right {
     display: block;
+    width:100vw;
+}
+
+.info-right .info-rm .info-rm-overview {
+    width: 95vw;
 }
 
 .info-right .info-rt * > button {
@@ -58,6 +63,11 @@
 .info-right .info-rb {
     overflow-x: scroll;
     height:fit-content;
+    width:90vw;
+
+    position: relative;
+    left:46%;
+    transform:translate(-50%, 0);
 }
 
 .info-rb .info-rb-grid {
@@ -92,7 +102,11 @@
 
 .review-page {
     overflow-y: scroll;
+    position: relative;
+    left:46%;
+    transform: translate(-50%, 0);
     height: 30vh;
+    width: 90vw;
 }
 
 .review-box {

--- a/css/mystyle.css
+++ b/css/mystyle.css
@@ -28,7 +28,7 @@ body {
 
 .card-container {
     background-color: transparent;
-    width: 100%;
+    width: 100vw;
     height: fit-content;
     overflow-y: hidden;
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#39 
## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->

- transition 추가 이후 발생한 css 문제를 해결했습니다. (899px 이하의 viewport에서 리뷰 및 배우 목록 container가 화면을 벗어나던 문제)

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->